### PR TITLE
Improve markup of the spotify tag

### DIFF
--- a/lib/buckygem/spotify_tag.rb
+++ b/lib/buckygem/spotify_tag.rb
@@ -16,11 +16,11 @@ module Buckygem
 
     def render(_context)
       <<~RENDERED_HTML
-        <p>
-          <a href="http://open.spotify.com/user/#{@playlist_author}/playlist/#{@playlist_id}">
+        <div>
+          <a class="button" href="http://open.spotify.com/user/#{@playlist_author}/playlist/#{@playlist_id}">
             écouter sur Spotify
           </a>
-        </p>
+        </div>
       RENDERED_HTML
     end
   end

--- a/spec/spotify_tag_spec.rb
+++ b/spec/spotify_tag_spec.rb
@@ -6,11 +6,11 @@ describe Buckygem::SpotifyTag do
   describe '#tag' do
     it 'can output a date in english' do
       expected_output = <<~EXPECTED_OUTPUT
-        <p>
-          <a href="http://open.spotify.com/user/author/playlist/1234">
+        <div>
+          <a class="button" href="http://open.spotify.com/user/author/playlist/1234">
             écouter sur Spotify
           </a>
-        </p>
+        </div>
       EXPECTED_OUTPUT
 
       template = Liquid::Template.parse('{% spotify 1234 author %}')


### PR DESCRIPTION
This PR improves the semantics of the `spotify` Liquid tag to use `<div>` instead of `<p>`. 
It also adds a `button` class to the anchor link to the playlist.